### PR TITLE
Parallel execution of multiple commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.9.0",
     "mocha": "^3.3.0",
+    "p-wait-for": "^1.0.0",
     "sinon": "^2.2.0"
+  },
+  "dependencies": {
+    "p-map": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-preset-env": "^1.4.0",
     "babel-register": "^6.24.1",
     "chai": "^3.5.0",
+    "chai-iterator": "^1.1.4",
     "eslint": "^3.15.0",
     "eslint-config-actano": "^6.1.0",
     "eslint-plugin-import": "^2.2.0",

--- a/src/context.js
+++ b/src/context.js
@@ -1,10 +1,12 @@
 import assert from 'assert'
 import pMap from 'p-map'
-import { isFunction, isString, isPromise, isCommand, isGenerator, generatorForSingleValue } from './utils'
+import { isFunction, isString, isPromise, isCommand, isGenerator, generatorForSingleValue,
+  isIterable } from './utils'
 
 export default class Context {
   constructor() {
     this._commands = {}
+    this._fork = this._fork.bind(this)
   }
 
   use(backend) {
@@ -38,9 +40,9 @@ export default class Context {
           }
         } else if (isPromise(value)) {
           nextValue = await value // eslint-disable-line no-await-in-loop
-        } else if (Array.isArray(value)) {
+        } else if (isIterable(value)) {
           // eslint-disable-next-line no-await-in-loop
-          nextValue = await pMap(value, this._fork.bind(this))
+          nextValue = await pMap(value, this._fork)
         } else {
           throw new Error(`Neither promise nor action was yielded: ${value}`)
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,8 @@ export const isCommand = value => !!value && isString(value.type)
 export const isGenerator = value =>
   !!value && isFunction(value.next) && isFunction(value.throw) && isFunction(value.return)
 
+export const isIterable = value => !!value && isFunction(value[Symbol.iterator])
+
 export const generatorForSingleValue = (value) => {
   function* generateSingleValue() {
     return yield value

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,3 +5,14 @@ export const isString = value => typeof value === 'string'
 export const isPromise = value => !!value && isFunction(value.then)
 
 export const isCommand = value => !!value && isString(value.type)
+
+export const isGenerator = value =>
+  !!value && isFunction(value.next) && isFunction(value.throw) && isFunction(value.return)
+
+export const generatorForSingleValue = (value) => {
+  function* generateSingleValue() {
+    return yield value
+  }
+
+  return generateSingleValue()
+}

--- a/test/context.js
+++ b/test/context.js
@@ -1,7 +1,11 @@
 import sinon from 'sinon'
-import { expect } from 'chai'
+import chai from 'chai'
+import chaiIterator from 'chai-iterator'
 import waitFor from 'p-wait-for'
 import Context from '../src/context'
+
+chai.use(chaiIterator)
+const { expect } = chai
 
 describe('borders/context', () => {
   it('should return result of generator', async () => {
@@ -56,6 +60,16 @@ describe('borders/context', () => {
   })
 
   describe('executing multiple commands at once', () => {
+    function createIterableOf(items) {
+      const iterable = {}
+      iterable[Symbol.iterator] = function* iterate() {
+        for (const item of items) {
+          yield item
+        }
+      }
+      return iterable
+    }
+
     it('should run multiple commands and return their results', async () => {
       const context = new Context()
       const backend = {
@@ -65,11 +79,11 @@ describe('borders/context', () => {
       context.use(backend)
 
       await context.execute(function* test() {
-        const result = yield [
+        const result = yield createIterableOf([
           { type: 'command1' },
           { type: 'command2' },
-        ]
-        expect(result).to.deep.equal([101, 102])
+        ])
+        expect(result).to.iterate.over([101, 102])
       }())
     })
 
@@ -92,11 +106,11 @@ describe('borders/context', () => {
       }
 
       await context.execute(function* test() {
-        const result = yield [
+        const result = yield createIterableOf([
           generator1(),
           generator2(),
-        ]
-        expect(result).to.deep.equal([91, 82])
+        ])
+        expect(result).to.iterate.over([91, 82])
       }())
     })
 
@@ -119,12 +133,12 @@ describe('borders/context', () => {
       context.use(backend)
 
       await context.execute(function* test() {
-        const result = yield [
+        const result = yield createIterableOf([
           { type: 'command1' },
           { type: 'command2' },
-        ]
+        ])
 
-        expect(result).to.deep.equal([101, 102])
+        expect(result).to.iterate.over([101, 102])
       }())
     })
   })


### PR DESCRIPTION
By `yield`ing an array of commands and/or generators, these instructions can be executed in parallel. Their respective results are returned as an array in the same order.

Example:
```javascript
const context = new Context()
const backend = {
  command1() { return 101 },
  command2() { return 102 },
}
context.use(backend)

await context.execute(function* test() {
  const result = yield [
    { type: 'command1' },
    { type: 'command2' },
  ]
  expect(result).to.deep.equal([101, 102])
}())
```